### PR TITLE
Switch to CDN React for Vercel

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,16 @@ npm start
 ```
 
 Then open [http://localhost:3000](http://localhost:3000) in your browser.
+
+### Deploying to Vercel
+
+You can deploy the app as a static site with the Vercel CLI:
+
+```bash
+npm install
+npx vercel --prod
+```
+
+When prompted, choose **Other** as the framework and leave the build command
+empty. Set the output directory to `.` (the project root). Vercel will then
+host `index.html` and `app.js` directly.

--- a/index.html
+++ b/index.html
@@ -7,8 +7,8 @@
 </head>
 <body>
   <div id="root"></div>
-  <script src="node_modules/react/umd/react.development.js"></script>
-  <script src="node_modules/react-dom/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/react@19/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@19/umd/react-dom.development.js" crossorigin></script>
   <script src="app.js"></script>
 </body>
 </html>

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "version": 2,
+  "builds": [{ "src": "index.html", "use": "@vercel/static" }]
+}


### PR DESCRIPTION
## Summary
- reference React from a CDN so the site doesn't rely on node_modules
- document how to deploy the static app on Vercel
- add a minimal `vercel.json`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68818d65b5948332bf76ed84f069b655